### PR TITLE
Allow Meta to be extracted from responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ if err := client.Authenticate(); err != nil {
 }
 
 products := []entities.Product{}
-_, err := client.Get("products", &products)
+_, err := client.Get("products", gomo.Data(&products))
 if err != nil {
 	log.Fatal(err)
 }

--- a/doc_test.go
+++ b/doc_test.go
@@ -27,7 +27,7 @@ func Example() {
 	}
 
 	// send the create request
-	wrapper, err := client.Post("products", &product)
+	wrapper, err := client.Post("products", gomo.Data(&product))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func Example() {
 	product.Name = "Updated Product"
 
 	// send the update request
-	wrapper, err = client.Put(fmt.Sprintf("products/%s", product.ID), &product)
+	wrapper, err = client.Put(fmt.Sprintf("products/%s", product.ID), gomo.Data(&product))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/entities/meta.go
+++ b/entities/meta.go
@@ -1,0 +1,15 @@
+package entities
+
+// Meta is returned from many queries that support pagination
+type Meta struct {
+	Results struct {
+		Total int `json:"total"`
+		All   int `json:"all"`
+	} `json:"results"`
+	Page struct {
+		Limit   int `json:"limit"`
+		Offset  int `json:"offset"`
+		Current int `json:"current"`
+		Total   int `json:"total"`
+	} `json:"page"`
+}

--- a/examples/total_orders.go
+++ b/examples/total_orders.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/moltin/gomo"
+	"github.com/moltin/gomo/entities"
+)
+
+func main() {
+	client := gomo.NewClient()
+	err := client.Authenticate()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var meta entities.Meta
+	_, err = client.Get("/orders", gomo.Meta(&meta))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Total orders: %d\n", meta.Results.Total)
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -21,36 +21,52 @@ type response struct {
 	Data     interface{} `json:"data"`
 	Meta     interface{} `json:"meta"`
 	Included interface{} `json:"included"`
+	Links    interface{} `json:"links"`
 	Errors   []APIError  `json:"errors"`
 }
 
-// newAPIWrapper creates a new wrapper for this call
-func newWrapper(method string, endpoint string, resources ...interface{}) wrapper {
+// Data sets the target for a responses data resource
+func Data(target interface{}) func(*wrapper) {
+	return func(w *wrapper) {
+		w.Body = target
+		w.Response.Data = target
 
-	var targetResource interface{}
-	var targetIncludes interface{}
-
-	for k, resource := range resources {
-		switch k {
-		case 0:
-			targetResource = resource
-		case 1:
-			targetIncludes = resource
+		// set the resource type if the entity has the SetType method
+		if resource, ok := target.(interface{ SetType() }); ok {
+			resource.SetType()
 		}
 	}
+}
 
-	// set the resource type if the entity has the SetType method
-	if targetResource, ok := targetResource.(interface{ SetType() }); ok {
-		targetResource.SetType()
+// Included sets the target for a responses included resource
+func Included(target interface{}) func(*wrapper) {
+	return func(w *wrapper) {
+		w.Response.Included = target
 	}
+}
 
-	return wrapper{
+// Meta sets the target for a responses meta resource
+func Meta(target interface{}) func(*wrapper) {
+	return func(w *wrapper) {
+		w.Response.Meta = target
+	}
+}
+
+// Links sets the target for a responses links resource
+func Links(target interface{}) func(*wrapper) {
+	return func(w *wrapper) {
+		w.Response.Links = target
+	}
+}
+
+// newWrapper creates a new wrapper for this call
+func newWrapper(method string, endpoint string, resources ...func(*wrapper)) wrapper {
+	wrapper := wrapper{
 		Method:   strings.ToUpper(method),
 		Endpoint: endpoint,
-		Body:     targetResource,
-		Response: response{
-			Data:     targetResource,
-			Included: targetIncludes,
-		},
 	}
+	for _, resource := range resources {
+		resource(&wrapper)
+	}
+	return wrapper
 }

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,55 @@
+package gomo
+
+import "testing"
+
+func TestData(t *testing.T) {
+	var w wrapper
+	Data("foobar")(&w)
+	if s, ok := w.Response.Data.(string); !ok || s != "foobar" {
+		t.Fatal("failed to set data")
+	}
+}
+
+func TestLinks(t *testing.T) {
+	var w wrapper
+	Links("foobar")(&w)
+	if s, ok := w.Response.Links.(string); !ok || s != "foobar" {
+		t.Fatal("failed to set links")
+	}
+}
+
+func TestIncluded(t *testing.T) {
+	var w wrapper
+	Included("foobar")(&w)
+	if s, ok := w.Response.Included.(string); !ok || s != "foobar" {
+		t.Fatal("failed to set included")
+	}
+}
+
+func TestMeta(t *testing.T) {
+	var w wrapper
+	Meta("foobar")(&w)
+	if s, ok := w.Response.Meta.(string); !ok || s != "foobar" {
+		t.Fatal("failed to set meta")
+	}
+}
+
+func TestNewWrapper(t *testing.T) {
+	called := false
+	w := newWrapper(
+		"method",
+		"endpoint",
+		func(wp *wrapper) {
+			called = true
+		},
+	)
+	if w.Method != "METHOD" {
+		t.Error("failed to set method")
+	}
+	if w.Endpoint != "endpoint" {
+		t.Error("failed to set endpoint")
+	}
+	if called == false {
+		t.Error("failed to call option function")
+	}
+}


### PR DESCRIPTION
This PR changes the way data is extracted from responses. Previously there was a position-dependant list of resources in the call, eg:
```
orders := []Order{}
includes := OrderIncluded{}
_, err := client.Get("/orders", &orders, &included)
```
Only the `data` and `included` parts of the response were supported.

This change introduces more flexible functional options and also supports `links` and `meta` sections of the response, eg:
```
orders := []Order{}
meta := Meta{}
_, err := client.Get("/orders", Data(&orders), Meta(&meta))
```